### PR TITLE
Added rsense autostart

### DIFF
--- a/lib/autocomplete-ruby-client.coffee
+++ b/lib/autocomplete-ruby-client.coffee
@@ -1,15 +1,59 @@
 $ = require('jquery')
-String.prototype.replaceAll = (s,r) -> @split(s).join(r)
+exec = require('child_process').exec
+String.prototype.replaceAll = (s, r) -> @split(s).join(r)
 
 module.exports =
 class RsenseClient
   projectPath: null
+  rsensePath: null
   serverUrl: null
+  rsenseStarted: null
 
   constructor: ->
     @projectPath = atom.project.getPaths()[0]
+    @projectPath = '.' unless @projectPath
+    @rsensePath = atom.config.get('autocomplete-ruby.rsensePath')
     port = atom.config.get('autocomplete-ruby.port')
     @serverUrl = "http://localhost:#{port}"
+    @rsenseStarted = false
+
+  startRsense: ->
+    # Before trying to start we need to kill any existing rsense servers, so
+    # as to not end up with multiple rsense servsers unkillable by 'rsense stop'
+    # This means that running two atoms and closing one, kills rsense for the other
+    return if @rsenseStarted == true
+    @rsenseStarted = true
+
+    exec("#{@rsensePath} stop",
+      (error, stdout, stderr) =>
+        if error == null
+
+          port = atom.config.get('autocomplete-ruby.port')
+          exec("#{@rsensePath} start --port #{port} -- path #{@projectPath}",
+            (error, stdout, stderr) ->
+              if error != null
+                atom.notifications.addError('Error starting rsense',
+                    {detail: "exec error: #{error}", dismissable: true}
+                  )
+                @rsenseStarted = false
+          )
+
+        else
+          atom.notifications.addError('Error stopping rsense',
+              {detail: "exec error: #{error}", dismissable: true}
+            )
+          @rsenseStarted = false
+    )
+
+  stopRsense: ->
+    exec("#{@rsensePath} stop",
+      (error, stdout, stderr) ->
+        if error != null
+          atom.notifications.addError('Error stopping rsense',
+              {detail: "exec error: #{error}", dismissable: true}
+            )
+        @rsenseStarted = false
+    )
 
   checkCompletion: (editor, buffer, row, column, callback) ->
     code = buffer.getText().replaceAll('\n', '\n').

--- a/lib/autocomplete-ruby-provider.coffee
+++ b/lib/autocomplete-ruby-provider.coffee
@@ -1,6 +1,6 @@
 RsenseClient = require './autocomplete-ruby-client.coffee'
 
-String.prototype.regExpEscape = () ->
+String.prototype.regExpEscape = ->
   return @replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
 
 module.exports =
@@ -14,6 +14,7 @@ class RsenseProvider
     @lastSuggestions = []
 
   requestHandler: (options) ->
+    @rsenseClient.startRsense() unless @rsenseClient.rsenseStarted
     return new Promise (resolve) =>
       # rsense expects 1-based positions
       row = options.cursor.getBufferRow() + 1
@@ -61,3 +62,4 @@ class RsenseProvider
     return suggestionBuffer
 
   dispose: ->
+    @rsenseClient.stopRsense() if @rsenseClient.rsenseStarted

--- a/lib/autocomplete-ruby.coffee
+++ b/lib/autocomplete-ruby.coffee
@@ -2,6 +2,10 @@ RsenseProvider = require './autocomplete-ruby-provider.coffee'
 
 module.exports =
   config:
+    rsensePath:
+      description: 'The location of the rsense executable'
+      type: 'string'
+      default: '~/.gem/ruby/2.3.0/bin/rsense'
     port:
       description: 'The port the rsense server is running on'
       type: 'integer'

--- a/spec/autocomplete-ruby-spec.coffee
+++ b/spec/autocomplete-ruby-spec.coffee
@@ -6,7 +6,18 @@ describe "AutocompleteRuby", ->
   beforeEach ->
     workspaceElement = atom.views.getView(atom.workspace)
     activationPromise = atom.packages.activatePackage('autocomplete-ruby')
+    waitsForPromise -> activationPromise
 
   describe "autocomplete-ruby", ->
-    it "contains spec with an expectation", ->
-      expect(true).toBe(true)
+    it 'Starts and stops rsense', ->
+      rsenseProvider = AutocompleteRuby.rsenseProvider
+      rsenseClient = rsenseProvider.rsenseClient
+
+      expect(rsenseClient.rsenseStarted).toBe(false)
+
+      # The first request for autocompletion starts rsense
+      rsenseProvider.requestHandler()
+      expect(rsenseClient.rsenseStarted).toBe(true)
+
+      rsenseClient.stopRsense()
+      expect(rsenseClient.rsenseStarted).toBe(true)


### PR DESCRIPTION
**Added:**
- Rsense does not start before the first request for autcompletion is made, and
  rsense only starts if not already started by this instance of ruby-autcompletion
- Test specs for starting and stopping rsense

This implementation of rsense autostart does not keep track of multiple instances of autocomplete-ruby, which means if a second atom windows is launched, rsense restarts. If two atom windows are open with autocomplete-ruby and one of them is closed, rsense stops.

This implementation tries to stop any "lingering" rsense servers before starting any, this is neccessary because if any rsense server is running and someone calls "rsense start", a second instance is launched without a PID file, clogging up the system.

**Side note:**
It would be useful if we could spawn multiple instances of rsense, with their own PID files, or something like that, but that is for the rsense repo, not this. Or perhaps a command to check if rsense is already running.
