### PR TITLE
Improve Rsense process managment for Unix systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ apm install autocomplete-plus
 ## Usage
 Just type some stuff, and autocomplete+ will automatically show you some suggestions.
 
-Note: It might take about 10 seconds after the first suggestions pop up before rsense will give you any suggestions.
+Note: If you use Winows, it might take about 10 seconds after the first suggestions pop up before rsense will give you any suggestions.
 
 ## Bugs
 A lot. If you're brave enough to try this out and notice any specifically, feel free to open an issue or even better submit a pull request.

--- a/lib/autocomplete-ruby-provider.coffee
+++ b/lib/autocomplete-ruby-provider.coffee
@@ -1,4 +1,5 @@
 RsenseClient = require './autocomplete-ruby-client.coffee'
+IS_WIN = process.platform == 'win32'
 
 String.prototype.regExpEscape = () ->
   return @replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
@@ -14,10 +15,11 @@ class RsenseProvider
 
   constructor: ->
     @rsenseClient = new RsenseClient()
+    @rsenseClient.startRsenseUnix() if !IS_WIN
     @lastSuggestions = []
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
-    @rsenseClient.startRsense()
+    @rsenseClient.startRsenseWin32() if IS_WIN
     new Promise (resolve) =>
       # rsense expects 1-based positions
       row = bufferPosition.row + 1
@@ -73,4 +75,4 @@ class RsenseProvider
     return suggestionBuffer
 
   dispose: ->
-    @rsenseClient.stopRsense() if @rsenseClient.rsenseStarted
+    @rsenseClient.stopRsense()

--- a/lib/autocomplete-ruby-provider.coffee
+++ b/lib/autocomplete-ruby-provider.coffee
@@ -1,5 +1,5 @@
 RsenseClient = require './autocomplete-ruby-client.coffee'
-IS_WIN = process.platform == 'win32'
+IS_WIN32 = process.platform == 'win32'
 
 String.prototype.regExpEscape = () ->
   return @replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
@@ -15,11 +15,11 @@ class RsenseProvider
 
   constructor: ->
     @rsenseClient = new RsenseClient()
-    @rsenseClient.startRsenseUnix() if !IS_WIN
+    @rsenseClient.startRsenseUnix() if !IS_WIN32
     @lastSuggestions = []
 
   getSuggestions: ({editor, bufferPosition, scopeDescriptor, prefix}) ->
-    @rsenseClient.startRsenseWin32() if IS_WIN
+    @rsenseClient.startRsenseWin32() if IS_WIN32
     new Promise (resolve) =>
       # rsense expects 1-based positions
       row = bufferPosition.row + 1
@@ -75,4 +75,5 @@ class RsenseProvider
     return suggestionBuffer
 
   dispose: ->
-    @rsenseClient.stopRsense()
+    return @rsenseClient.stopRsense() if IS_WIN32
+    @rsenseClient.stopRsenseUnix()

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "dependencies": {
     "jquery": "^3",
-    "ps-node": "^0.1.3",
-    "current-processes": "^0.2.1"
+    "table-parser": "^0.1.3"
   },
   "providedServices": {
     "autocomplete.provider": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "atom": ">=0.174.0 <2.0.0"
   },
   "dependencies": {
-    "jquery": "^3"
+    "jquery": "^3",
+    "ps-node": "^0.1.3",
+    "current-processes": "^0.2.1"
   },
   "providedServices": {
     "autocomplete.provider": {

--- a/spec/autocomplete-ruby-spec.coffee
+++ b/spec/autocomplete-ruby-spec.coffee
@@ -4,9 +4,15 @@ describe "AutocompleteRuby", ->
   [workspaceElement, activationPromise] = []
 
   beforeEach ->
-    workspaceElement = atom.views.getView(atom.workspace)
-    activationPromise = atom.packages.activatePackage('autocomplete-ruby')
-    waitsForPromise -> activationPromise
+    atom.config.set('autocomplete-plus.enableAutoActivation', true)
+    waitsForPromise ->
+      Promise.all [
+        atom.workspace.open('sample.js').then (e) ->
+          editor = e
+          editorView = atom.views.getView(editor)
+        atom.packages.activatePackage('autocomplete-plus')
+        atom.packages.activatePackage('autocomplete-ruby')
+      ]
 
   describe "autocomplete-ruby", ->
     it 'Starts and stops rsense', ->
@@ -16,7 +22,7 @@ describe "AutocompleteRuby", ->
       expect(rsenseClient.rsenseStarted).toBe(false)
 
       # The first request for autocompletion starts rsense
-      rsenseProvider.requestHandler()
+      rsenseProvider.getSuggestions()
       expect(rsenseClient.rsenseStarted).toBe(true)
 
       rsenseClient.stopRsense()

--- a/spec/autocomplete-ruby-spec.coffee
+++ b/spec/autocomplete-ruby-spec.coffee
@@ -4,15 +4,9 @@ describe "AutocompleteRuby", ->
   [workspaceElement, activationPromise] = []
 
   beforeEach ->
-    atom.config.set('autocomplete-plus.enableAutoActivation', true)
-    waitsForPromise ->
-      Promise.all [
-        atom.workspace.open('sample.js').then (e) ->
-          editor = e
-          editorView = atom.views.getView(editor)
-        atom.packages.activatePackage('autocomplete-plus')
-        atom.packages.activatePackage('autocomplete-ruby')
-      ]
+    workspaceElement = atom.views.getView(atom.workspace)
+    activationPromise = atom.packages.activatePackage('autocomplete-ruby')
+    waitsForPromise -> activationPromise
 
   describe "autocomplete-ruby", ->
     it 'Starts and stops rsense', ->
@@ -22,7 +16,7 @@ describe "AutocompleteRuby", ->
       expect(rsenseClient.rsenseStarted).toBe(false)
 
       # The first request for autocompletion starts rsense
-      rsenseProvider.getSuggestions()
+      rsenseProvider.requestHandler()
       expect(rsenseClient.rsenseStarted).toBe(true)
 
       rsenseClient.stopRsense()


### PR DESCRIPTION
This improves the starting and stopping for the Rsense process for Unix based systems.

When atom starts it checks if an rsense process is already running. If yes, then do nothing, otherwise start the rsense server.

Once you close the atom window it first checks how many atom windows are open. If there are more than one then do nothing, because we still want to use Rsense in the other window. If there's only one window open then kill the rsense server. (No problems anymore with rsense processes without a pidfile)

I could only implement this for Unix. If the user is using windows it falls back on the old starting/stopping mechanism. If someone wants to do it for windows, be my guest :)
