### PR TITLE
Fix default rsense path

### DIFF
--- a/lib/autocomplete-ruby.coffee
+++ b/lib/autocomplete-ruby.coffee
@@ -1,11 +1,13 @@
 RsenseProvider = require './autocomplete-ruby-provider.coffee'
 
+GEM_HOME = process.env.GEM_HOME ? '~/.gem/ruby/2.3.0'
+
 module.exports =
   config:
     rsensePath:
       description: 'The location of the rsense executable'
       type: 'string'
-      default: '~/.gem/ruby/2.3.0/bin/rsense'
+      default: "#{GEM_HOME}/bin/rsense"
     port:
       description: 'The port the rsense server is running on'
       type: 'integer'


### PR DESCRIPTION
Use `GEM_HOME` if it exists.

Signed-off-by: Daniel Bayley <daniel.bayley@me.com>