### PR TITLE
Attempt to be more agnostic when fetching gem directory

### DIFF
--- a/lib/autocomplete-ruby.coffee
+++ b/lib/autocomplete-ruby.coffee
@@ -1,20 +1,5 @@
 RsenseProvider = require './autocomplete-ruby-provider.coffee'
-exec = require('child_process').exec
-
-platformHome = process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']
-
-getExecPathFromGemEnv = ->
-  exec 'gem environment', (err, stdout, stderr) ->
-    unless err
-      line = stdout.split(/(\r)?\n/)
-               .find((l) -> ~l.indexOf('EXECUTABLE DIRECTORY'))
-      if line
-        line[line.indexOf(': ')..]
-      else
-        undefined
-
-GEM_HOME = process.env.GEM_HOME ? getExecPathFromGemEnv() ? "#{platformHome}/.gem/ruby/2.3.0"
-  
+GEM_HOME = require('./gem-home.coffee')
 
 module.exports =
   config:

--- a/lib/autocomplete-ruby.coffee
+++ b/lib/autocomplete-ruby.coffee
@@ -6,7 +6,7 @@ module.exports =
     rsensePath:
       description: 'The location of the rsense executable'
       type: 'string'
-      default: "#{GEM_HOME}/bin/rsense"
+      default: "#{GEM_HOME}/rsense"
     port:
       description: 'The port the rsense server is running on'
       type: 'integer'

--- a/lib/autocomplete-ruby.coffee
+++ b/lib/autocomplete-ruby.coffee
@@ -1,6 +1,20 @@
 RsenseProvider = require './autocomplete-ruby-provider.coffee'
+exec = require('child_process').exec
 
-GEM_HOME = process.env.GEM_HOME ? '~/.gem/ruby/2.3.0'
+platformHome = process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']
+
+getExecPathFromGemEnv = ->
+  exec 'gem environment', (err, stdout, stderr) ->
+    unless err
+      line = stdout.split(/(\r)?\n/)
+               .find((l) -> ~l.indexOf('EXECUTABLE DIRECTORY'))
+      if line
+        line[line.indexOf(': ')..]
+      else
+        undefined
+
+GEM_HOME = process.env.GEM_HOME ? getExecPathFromGemEnv() ? "#{platformHome}/.gem/ruby/2.3.0"
+  
 
 module.exports =
   config:

--- a/lib/gem-home.coffee
+++ b/lib/gem-home.coffee
@@ -1,0 +1,15 @@
+execSync = require('child_process').execSync
+
+platformHome = process.env[if process.platform is 'win32' then 'USERPROFILE' else 'HOME']
+
+getExecPathFromGemEnv = ->
+  stdout = execSync 'gem environment'
+
+  line = stdout.toString().split(/\r?\n/)
+           .find((l) -> ~l.indexOf('EXECUTABLE DIRECTORY'))
+  if line
+    line[line.indexOf(': ') + 2..]
+  else
+    undefined
+
+module.exports = process.env.GEM_HOME ? getExecPathFromGemEnv() ? "#{platformHome}/.gem/ruby/2.3.0"


### PR DESCRIPTION
I'm not really able to test it, but this is the general direction needed to use the correct path for rsense.
Ideally either the first or second method should work, but the third is there for extra safety (though it will probably not work on Windows)

- [x] reliable way to determine default gem location in Linux/OSX
- [x] reliable way to determine default gem location in Windows