### PR TITLE
Correct $GEM_HOME behavior

### DIFF
--- a/lib/gem-home.coffee
+++ b/lib/gem-home.coffee
@@ -12,4 +12,10 @@ getExecPathFromGemEnv = ->
   else
     undefined
 
-module.exports = process.env.GEM_HOME ? getExecPathFromGemEnv() ? "#{platformHome}/.gem/ruby/2.3.0"
+gemHome = ->
+  if process.env.GEM_HOME
+    "#{process.env.GEM_HOME}/bin"
+  else
+    getExecPathFromGemEnv() ? "#{platformHome}/.gem/ruby/2.3.0"
+
+module.exports = gemHome()


### PR DESCRIPTION
Fixes the case where the default rsense setting is:

       GEM_HOME=~/.gem/ruby/{{version}}

    Previously: ~/.gem/ruby/{{version}}/rsense
       Correct: ~/.gem/ruby/{{version}}/bin/rsense